### PR TITLE
폰트 .ttf 확장자 404 에러

### DIFF
--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -8,7 +8,7 @@ export const GlobalStyle = createGlobalStyle`
   }
   @font-face {
     font-family: 'Pretendard';
-    src: url(/fonts/Pretendard-Regular.tts);
+    src: url(/fonts/Pretendard-Regular.ttf);
   }
   ${reset}
   * {

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -8,7 +8,7 @@ export const GlobalStyle = createGlobalStyle`
   }
   @font-face {
     font-family: 'Pretendard';
-    src: url(/fonts/Pretendard-Regular.ttf);
+    src: url(/fonts/Pretendard-Regular.woff2);
   }
   ${reset}
   * {


### PR DESCRIPTION
## 📌 Related Issue
#19 

## 🛠 Task
- 폰트 .ttf 확장자 404 에러 (public에 등록된 폰트 확장자와 맞지 않아 404 에러 발생)